### PR TITLE
_currentLoadQueue

### DIFF
--- a/Assets/ABSystem/Scripts/AssetBundle/AssetBundleManager.cs
+++ b/Assets/ABSystem/Scripts/AssetBundle/AssetBundleManager.cs
@@ -45,7 +45,7 @@ namespace Tangzx.ABSystem
         /// <summary>
         /// 加载队列
         /// </summary>
-        private List<AssetBundleLoader> _currentLoadQueue = new List<AssetBundleLoader>();
+        private HashSet<AssetBundleLoader> _currentLoadQueue = new HashSet<AssetBundleLoader>();
         /// <summary>
         /// 未完成的
         /// </summary>


### PR DESCRIPTION
短时间内创建相同的loader 在LoadComplete会造成少移除 导致_isCurrentLoading一直为true 不能卸载ab文件